### PR TITLE
Use nokogiri v1.12.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,11 +173,11 @@ GEM
       nokogiri (~> 1)
       rake
     mini_mime (1.1.2)
-    mini_portile2 (2.7.1)
+    mini_portile2 (2.6.1)
     minitest (5.15.0)
     nio4r (2.5.8)
-    nokogiri (1.13.1)
-      mini_portile2 (~> 2.7.0)
+    nokogiri (1.12.5)
+      mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
     public_suffix (4.0.6)
     puma (4.3.11)
@@ -249,4 +249,4 @@ DEPENDENCIES
   slim-jets
 
 BUNDLED WITH
-   2.1.4
+   2.3.7


### PR DESCRIPTION
>Your bundle is locked to nokogiri (1.13.1) from rubygems repository https://rubygems.org/ or installed locally, but that version can no longer be found in that source. That means the author of nokogiri (1.13.1) has removed it. You'll need to update your bundle to a version other than nokogiri (1.13.1) that hasn't been removed in order to install.

と言われていたので bundle update nokogiri した。バージョンは下がった(？)。
