### PR TITLE
日記のフィードを出力するぞ

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "axios": "^0.27.2",
         "express": "^4.17.3",
+        "feed": "^4.2.2",
         "pug": "^3.0.2"
       },
       "devDependencies": {
@@ -715,6 +716,17 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/feed": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/feed/-/feed-4.2.2.tgz",
+      "integrity": "sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ==",
+      "dependencies": {
+        "xml-js": "^1.6.11"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/fill-range": {
@@ -1847,6 +1859,11 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "node_modules/sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
     "node_modules/semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -2391,6 +2408,17 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "node_modules/xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "xml-js": "bin/cli.js"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -2985,6 +3013,14 @@
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
+      }
+    },
+    "feed": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/feed/-/feed-4.2.2.tgz",
+      "integrity": "sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ==",
+      "requires": {
+        "xml-js": "^1.6.11"
       }
     },
     "fill-range": {
@@ -3812,6 +3848,11 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -4210,6 +4251,14 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "requires": {
+        "sax": "^1.2.4"
+      }
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "axios": "^0.27.2",
     "express": "^4.17.3",
+    "feed": "^4.2.2",
     "pug": "^3.0.2"
   },
   "devDependencies": {

--- a/src/routes/nikki/index.ts
+++ b/src/routes/nikki/index.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import axios from "axios";
+import { Feed } from "feed";
 
 const router = express.Router();
 const nikkiRegex = /^\d{4}-\d{2}-\d{2} \w{3} : /;
@@ -16,6 +17,59 @@ router.get("/", (request: express.Request, response: express.Response) => {
     });
 
     response.render("nikki/index", { layout: "layout", title: "Nikki", nikkis: nikkis });
+  }).catch((error) => {
+    console.log(error);
+  });
+});
+
+router.get("/atom.xml", (request: express.Request, response: express.Response) => {
+  const url = scrapboxApiBaseUrl + encodeURIComponent("日記");
+
+  axios.get(url).then((scrapbox) => {
+    const nikkis = scrapbox.data["relatedPages"]["links1hop"].filter((page: any) => {
+      return page.title.match(nikkiRegex) && !page.title.includes("(書きかけ)");
+    }).sort((a: any, b: any) => {
+      return b.title.localeCompare(a.title);
+    }).slice(0, 10);
+
+    const latestNikki = nikkis[0];
+    const latestNikkiDate = new Date(latestNikki.updated * 1000);
+
+    const feed = new Feed({
+      title: "june29の日記",
+      description: "june29がScrapboxで書いている日記です",
+      id: "https://scrapbox.io/june29",
+      link: "https://scrapbox.io/june29",
+      language: "ja",
+      image: "https://june29.jp/img/ring.jpg",
+      favicon: "https://scrapbox.io/assets/img/favicon/favicon.ico",
+      copyright: "All rights reserved " + latestNikkiDate.getFullYear() + ", june29",
+      updated: latestNikkiDate,
+      generator: "https://api.june29.jp/",
+      feedLinks: {
+        atom: "https://api.june29.jp/nikki/atom.xml"
+      },
+      author: {
+        name: "Jun OHWADA / june29",
+        email: "june29.jp@gmail.com",
+        link: "https://june29.jp"
+      }
+    });
+
+    nikkis.forEach((nikki: any) => {
+      const link = `https://scrapbox.io/june29/${encodeURIComponent(nikki.titleLc)}`;
+
+      feed.addItem({
+        title: nikki.title,
+        description: nikki.descriptions[0],
+        id: link,
+        link: link,
+        content: "",
+        date: new Date(nikki.updated * 1000)
+      });
+    });
+
+    response.send(feed.atom1());
   }).catch((error) => {
     console.log(error);
   });


### PR DESCRIPTION
Scrapbox で日記を書いています。
https://scrapbox.io/june29/

この Scrapbox のフィードをフィードリーダに登録して更新をチェックしてくれている人が何名か存在するようで、しかし、フィードリーダだと「ページが作成された」というタイミングで更新を拾ってしまい、書き上がった日記を読みたいというニーズにはマッチしません。

そこで、書き上がった日記の更新情報のみを扱うフィードを用意してみよう、という試みです。

https://api.june29.jp/nikki/atom.xml が建設予定地です。
