### PR TITLE
Scrapbox の API で最近つくられたページを取ってきて、そこからフィードをつくる

### DIFF
--- a/src/routes/nikki/index.ts
+++ b/src/routes/nikki/index.ts
@@ -23,10 +23,10 @@ router.get("/", (request: express.Request, response: express.Response) => {
 });
 
 router.get("/atom.xml", (request: express.Request, response: express.Response) => {
-  const url = scrapboxApiBaseUrl + encodeURIComponent("日記");
+  const url = "https://scrapbox.io/api/pages/june29?sort=created&limit=30";
 
   axios.get(url).then((scrapbox) => {
-    const nikkis = scrapbox.data["relatedPages"]["links1hop"].filter((page: any) => {
+    const nikkis = scrapbox.data.pages.filter((page: any) => {
       return page.title.match(nikkiRegex) && !page.title.includes("(書きかけ)");
     }).sort((a: any, b: any) => {
       return b.title.localeCompare(a.title);
@@ -57,7 +57,7 @@ router.get("/atom.xml", (request: express.Request, response: express.Response) =
     });
 
     nikkis.forEach((nikki: any) => {
-      const link = `https://scrapbox.io/june29/${encodeURIComponent(nikki.titleLc)}`;
+      const link = `https://scrapbox.io/june29/${encodeURIComponent(nikki.title)}`;
       const description = nikki.descriptions.filter((line: string) => {
         return !(line.startsWith("[***") || line.startsWith("[https://gyazo.com/"));
       }).map((line: string) => {


### PR DESCRIPTION
もともとは「日記」にリンクされたページの一覧を取得してそこから日付の新しい日記の最新 10 件を抽出して、というフィードの組み立て方をしていた。

しかし「日記」にリンクされたページの総数が 1,000 件に達してしまったからなのか、2022-05-17 以降の日記がフィードに載ってこないことに気付いた。

```rb
> puts Date.new(2019, 8, 23) + 1000
2022-05-19

# 2019-08-23 から書き始めた Scrapbox 日記、気付けば 1,000 日も続いている
```

そこで、別の取得元として https://scrapbox.io/api/pages/june29?sort=created&limit=30 のデータを使ってみることにした。最新の 30 ページを取得して、そこから日記のページのみを抽出してフィードをつくる。結果的にとても素直な処理に到達したように思う。処理時間も短くなりそう。
